### PR TITLE
fix(pgsql): reset epgsql sync_required connection before returning to pool

### DIFF
--- a/src/db_adapters/boss_db_adapter_pgsql.erl
+++ b/src/db_adapters/boss_db_adapter_pgsql.erl
@@ -180,8 +180,20 @@ execute_batch(Conn, Statement, Batch) ->
 
 transaction(Conn, TransactionFun) ->
     case epgsql:with_transaction(Conn, fun(_C) -> TransactionFun() end) of
-        {rollback, Reason} -> {aborted, Reason};
-        Other -> {atomic, Other}
+        {rollback, {badmatch, {error, sync_required}} = Reason} ->
+            %% The connection lost protocol sync with Postgres (a previous command
+            %% errored mid-protocol, leaving unread bytes in the wire buffer).
+            %% epgsql blocks ALL commands on this connection until sync_required=false,
+            %% including the ROLLBACK already attempted inside with_transaction.
+            %% epgsql:sync/1 is the only command exempt from this gate — it sends
+            %% the protocol-level Sync message, receives ReadyForQuery, and clears
+            %% the flag before this connection is returned to the poolboy pool.
+            epgsql:sync(Conn),
+            {aborted, Reason};
+        {rollback, Reason} ->
+            {aborted, Reason};
+        Other ->
+            {atomic, Other}
     end.
 
 get_migrations_table(Conn) ->

--- a/src/db_adapters/boss_db_adapter_pgsql.erl
+++ b/src/db_adapters/boss_db_adapter_pgsql.erl
@@ -183,12 +183,20 @@ transaction(Conn, TransactionFun) ->
         {rollback, {badmatch, {error, sync_required}} = Reason} ->
             %% The connection lost protocol sync with Postgres (a previous command
             %% errored mid-protocol, leaving unread bytes in the wire buffer).
-            %% epgsql blocks ALL commands on this connection until sync_required=false,
-            %% including the ROLLBACK already attempted inside with_transaction.
-            %% epgsql:sync/1 is the only command exempt from this gate — it sends
-            %% the protocol-level Sync message, receives ReadyForQuery, and clears
-            %% the flag before this connection is returned to the poolboy pool.
+            %% epgsql blocks ALL commands including the ROLLBACK that with_transaction
+            %% attempts in its catch block (epgsql.erl:476) — the result is discarded
+            %% and {rollback, Reason} is returned regardless, so ROLLBACK never reached
+            %% Postgres. Two independent states need resetting:
+            %% 1. epgsql client: epgsql:sync/1 sends the protocol-level Sync message,
+            %%    receives ReadyForQuery, and sets sync_required=false
+            %%    (epgsql_cmd_sync.erl:24). It is the only command exempt from the
+            %%    sync_required gate (epgsql_sock.erl:376-381).
+            %% 2. Postgres server: if BEGIN was sent before sync_required was triggered,
+            %%    the session still has an open transaction. epgsql:squery/2 sends
+            %%    ROLLBACK to close it. Safe unconditionally — a no-op warning if no
+            %%    transaction is open.
             epgsql:sync(Conn),
+            epgsql:squery(Conn, "ROLLBACK"),
             {aborted, Reason};
         {rollback, Reason} ->
             {aborted, Reason};


### PR DESCRIPTION
## Summary

- When epgsql loses protocol sync with Postgres mid-command (e.g. query timeout leaving unread bytes on the wire), it sets `sync_required=true` on the connection. Every subsequent command — including the `ROLLBACK` that `epgsql:with_transaction` attempts in its catch block — is blocked immediately with `{error, sync_required}` by `command_exec/4` in `epgsql_sock.erl` (line 376–381).
- `boss_db:transaction/1` calls `poolboy:checkin` unconditionally after every transaction, so the broken connection re-enters the pool in its broken state. The next caller that checks it out hits the same failure; all `bsh_pg_interface` retries may land on the same broken connection.
- `epgsql:sync/1` (using `epgsql_cmd_sync`) is the **only** command exempt from the `sync_required` gate. It sends the protocol-level `Sync` message, receives `ReadyForQuery` from Postgres, and clears `sync_required=false` (`epgsql_cmd_sync.erl:execute/2`) before the connection is returned to the pool.

## Root cause evidence

| Code location | Evidence |
|---|---|
| `epgsql_sock.erl:376–381` | `command_exec` guard blocks all commands when `sync_required=true` except `epgsql_cmd_sync` |
| `epgsql.erl:475–476` | `with_transaction` catch calls `squery(C, "ROLLBACK")` — `squery` maps to `epgsql_cmd_squery`, which **is** blocked |
| `boss_db.erl:418` | `poolboy:checkin(get_pool_name(), Worker)` is unconditional — broken connection always re-enters pool |
| `epgsql_cmd_sync.erl:24` | `set_attr(sync_required, false, Sock)` — only this command clears the flag |

## Change

Added a specific `{rollback, {badmatch, {error, sync_required}}}` clause in `transaction/2` that calls `epgsql:sync(Conn)` to restore the connection to a clean state before poolboy returns it to the pool.

## Test plan

- Unit: trigger a `sync_required` state on a connection by issuing a malformed extended-query sequence, then verify that subsequent transactions on the same connection succeed after the fix (previously all would fail until the connection was evicted).
- Integration: reproduce the `{aborted, {badmatch, {error, sync_required}}}` error under concurrent load; confirm it no longer propagates to callers after retries.

## Related

- Reported via GM-289532 (MeliSP04 `transport_job_complete` not received — traced to silent `get_existing_request_ids/4` failure caused by broken poolboy connection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)